### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/AutomationTesting.yml
+++ b/.github/workflows/AutomationTesting.yml
@@ -1,5 +1,8 @@
 name: Playwright Tests
 
+permissions:
+  contents: read
+
 on:
   repository_dispatch:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/kcd20/AI-Trip-Planner-Frontend/security/code-scanning/1](https://github.com/kcd20/AI-Trip-Planner-Frontend/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions:` block in the workflow to restrict the `GITHUB_TOKEN` to the minimum necessary scopes. For this workflow, the steps only require reading repository contents to check out code; uploading artifacts does not need repository write permissions. A minimal and safe configuration is `permissions: contents: read`.

The best fix without changing functionality is to add a `permissions:` section at the workflow root (top level, alongside `name:` and `on:`). This will apply to all jobs that do not override permissions. Specifically, in `.github/workflows/AutomationTesting.yml`, between line 1 (`name: Playwright Tests`) and line 3 (`on:`), insert:

```yml
permissions:
  contents: read
```

No additional imports or method definitions are needed, as this is purely a YAML configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
